### PR TITLE
Coupling Order etc

### DIFF
--- a/Parameters.fr
+++ b/Parameters.fr
@@ -419,42 +419,21 @@ M$Parameters = {
     TeX              -> Subscript[s,\[Phi]],
     Description      -> "Sine of phi"
   }, 
-  mu12=={
-    ParameterType    -> Internal,
-    Value            -> (MHL^2*(1 + cab^2 - sab^2) + MHH^2*(1 - cab^2 + sab^2))/4
-  },
-  mu22=={
-    ParameterType    -> Internal,
-    Value            -> (MHpH^2*(1 + cphi^2 - sphi^2) + MHp^2*(1 - cphi^2 + sphi^2) - lam3*vev^2)/2 
-  },
-  mu32=={
-    ParameterType    -> Internal,
-    Value            -> (cab*(-MHH^2 + MHL^2)*sab)/2
-  },
-  mueta2=={
-    ParameterType    -> Internal,
-    Value            -> (MHp^2*(1 + cphi^2 - sphi^2) + MHpH^2*(1 - cphi^2 + sphi^2) - lam8*vev^2)/2
-  },
-  muzee=={
-    ParameterType    -> Internal,
-    Value            -> (Sqrt[2]*cphi*(-MHp^2 + MHpH^2)*sphi)/vev,
-    InteractionOrder -> {QED,1}
-  },
   lam1 == {
     ParameterType    -> Internal,
-    Value            -> (MHL^2*(1 + cab^2 - sab^2) + MHH^2*(1 - cab^2 + sab^2))/(2*vev^2),
+    Value            -> (MHL^2*cab^2 + MHH^2*sab^2)/(vev^2),
     InteractionOrder -> {QED,2},
     Description      -> "lambda1"
   },
   lam4 == {
     ParameterType    -> Internal,
-    Value            -> (2*MHA^2 + MHH^2*(1 + cab^2 - sab^2) + MHL^2*(1 - cab^2 + sab^2) + 2*MHp^2*(-1 + cphi^2 - sphi^2) - 2*MHpH^2*(1 + cphi^2 - sphi^2))/(2*vev^2), 
+    Value            -> (MHA^2 + MHH^2*cab^2 + MHL^2*sab^2 - 2*MHp^2*sphi^2 - 2*MHpH^2*cphi^2)/(vev^2), 
     InteractionOrder -> {QED,2},
     Description      -> "lambda4"
   },
   lam5 == {
     ParameterType    -> Internal,
-    Value            -> (-2*MHA^2 + MHH^2*(1 + cab^2 - sab^2) + MHL^2*(1 - cab^2 + sab^2))/(2*vev^2),
+    Value            -> (-MHA^2 + MHH^2*cab^2 + MHL^2*sab^2)/(vev^2),
     InteractionOrder -> {QED,2},
     Description      -> "lambda5"
   },
@@ -463,6 +442,27 @@ M$Parameters = {
     Value            -> (cab*(-MHH^2 + MHL^2)*sab)/vev^2,
     InteractionOrder -> {QED,2},
     Description      -> "lambda6"
+  },
+  mu12=={
+    ParameterType    -> Internal,
+    Value            -> lam1*vev^2/2
+  },
+  mu22=={
+    ParameterType    -> Internal,
+    Value            -> (2*MHpH^2*cphi^2 + 2*MHp^2*sphi^2 - lam3*vev^2)/2 
+  },
+  mu32=={
+    ParameterType    -> Internal,
+    Value            -> lam6*vev^2/2
+  },
+  mueta2=={
+    ParameterType    -> Internal,
+    Value            -> (2*MHp^2*cphi^2 + 2*MHpH^2*sphi^2 - lam8*vev^2)/2
+  },
+  muzee=={
+    ParameterType    -> Internal,
+    Value            -> (Sqrt[2]*cphi*(-MHp^2 + MHpH^2)*sphi)/vev,
+    InteractionOrder -> {QED,1}
   },
   GHL == {
     ParameterType    -> Internal,

--- a/Parameters.fr
+++ b/Parameters.fr
@@ -145,7 +145,7 @@ M$Parameters = {
     BlockName     -> ZEELAMS,
     OrderBlock    -> 1,
     Value         -> 1,
-    InteractionOrder -> {ZEE,1},
+    InteractionOrder -> {QED,2},
     TeX           -> Subscript[\[Lambda],2],
     Description   -> "Quatric coupling 2"
   }, 
@@ -154,7 +154,7 @@ M$Parameters = {
     BlockName     -> ZEELAMS,
     OrderBlock    -> 2,
     Value         -> 1,
-    InteractionOrder -> {ZEE,1},
+    InteractionOrder -> {QED,2},
     TeX           -> Subscript[\[Lambda],3],
     Description   -> "Quatric coupling 3"
   }, 
@@ -163,7 +163,7 @@ M$Parameters = {
     BlockName     -> ZEELAMS,
     OrderBlock    -> 3,
     Value         -> 1,
-    InteractionOrder -> {ZEE,1},
+    InteractionOrder -> {QED,2},
     TeX           -> Subscript[\[Lambda],7],
     Description   -> "Quatric coupling 7"
   },   
@@ -172,7 +172,7 @@ M$Parameters = {
     BlockName     -> ZEELAMS,
     OrderBlock    -> 4,
     Value         -> 1,
-    InteractionOrder -> {ZEE,1},
+    InteractionOrder -> {QED,2},
     TeX           -> Subscript[\[Lambda],8],
     Description   -> "Quatric coupling 8"
   }, 
@@ -181,7 +181,7 @@ M$Parameters = {
     BlockName     -> ZEELAMS,
     OrderBlock    -> 5,
     Value         -> 1,
-    InteractionOrder -> {ZEE,1},
+    InteractionOrder -> {QED,2},
     TeX           -> Subscript[\[Lambda],9],
     Description   -> "Quatric coupling 9"
   }, 
@@ -190,7 +190,7 @@ M$Parameters = {
     BlockName     -> ZEELAMS,
     OrderBlock    -> 6,
     Value         -> 1,
-    InteractionOrder -> {ZEE,1},
+    InteractionOrder -> {QED,2},
     TeX           -> Subscript[\[Lambda],10],
     Description   -> "Quatric coupling 10"
   }, 
@@ -199,7 +199,7 @@ M$Parameters = {
     BlockName     -> ZEELAMS,
     OrderBlock    -> 7,
     Value         -> 1,
-    InteractionOrder -> {ZEE,1},
+    InteractionOrder -> {QED,2},
     TeX           -> Subscript[\[Lambda],\[Eta]],
     Description   -> "Quatric coupling eta"
   }, 

--- a/ZEE.fr
+++ b/ZEE.fr
@@ -95,7 +95,8 @@ IndexStyle[Generation, f];
 
 M$InteractionOrderHierarchy = {
   {QCD, 1},
-  {QED, 2}
+  {QED, 2},
+  {ZEE, 2}
 };
 
 Get["Particles.fr"];


### PR DESCRIPTION
These commits contain following changes:
1. Change the coupling order of lam's to QED 2
2. Simplify a little bit the expression for lam/mu etc.
3. Add ZEE coupling order into the OrderHierarchy

